### PR TITLE
Set defaut interval to 20 minutes

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function herokuSelfPing(url, options) {
     options = {};
   }
 
-  options.interval = options.interval || 45 * 1000 * 60;
+  options.interval = options.interval || 20 * 1000 * 60;
   options.logger = options.logger || console.log;
   options.verbose = options.verbose || false;
 


### PR DESCRIPTION
New Heroku instances now rotate every 30 minutes instead of every hour
